### PR TITLE
set &scrolloff based on size of context text

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -521,6 +521,9 @@ local function open(ctx_nodes)
     return
   end
 
+  -- prevent cursor overlap with the context text
+  vim.wo.scrolloff = #contexts
+
   set_lines(gbufnr, lno_text)
 
   highlight_contexts(bufnr, ctx_bufnr, contexts)


### PR DESCRIPTION
This PR would close issue https://github.com/romgrk/nvim-treesitter-context/issues/28, preventing the cursor from overlapping with the context text.