### PR TITLE
Include first line when looking for valid parent matches

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -352,7 +352,7 @@ local function get_parent_matches(max_lines)
     local row = parent:start()
 
     if is_valid(parent, vim.bo.filetype)
-        and row > 0
+        and row >= 0
         and row < (topline + #parent_matches - 1)
         and row ~= last_row then
       table.insert(parent_matches, 1, parent)


### PR DESCRIPTION
Fixes https://github.com/romgrk/nvim-treesitter-context/issues/91. As suggested in https://github.com/romgrk/nvim-treesitter-context/issues/91#issuecomment-1054939222